### PR TITLE
docs: add library-api epic spec

### DIFF
--- a/docs/specs/library-api/overview.md
+++ b/docs/specs/library-api/overview.md
@@ -1,0 +1,29 @@
+# Library API
+
+## Summary
+
+CLI ツールからライブラリへ転換し、EventEmitter ベースの `NotificationClient` を公開 API として提供する。
+
+## Background & Purpose
+
+現在の reverse-twitter-notifications は CLI ツール (`bun run src/index.ts start`) として動作し、プログラムから利用できない。Bot や自動化パイプラインに組み込むには、プログラマブルな API が必要。
+
+コアロジック (Autopush 接続、AESGCM 復号、Twitter 登録) は既にモジュール分割されており、高レベル API を被せてエクスポートするだけでライブラリ化できる。
+
+## Why Now
+
+- npm 公開に向けた最初のステップ
+- CLI 固有のコード (prompt, process.argv, Bun.file) がライブラリのコアに混入する前に分離すべき
+- 既にコアモジュールが安定しており、API レイヤーを追加するタイミングとして最適
+
+## Hypothesis
+
+- If we provide an EventEmitter-based API, then developers can integrate Twitter notifications into their bots/pipelines in under 10 lines of code
+- If we separate state management from the library, then users can persist state in any storage (file, DB, KV) without library-side I/O
+
+## Expected Outcome
+
+- `npm install reverse-twitter-notifications` でインストール可能
+- EventEmitter API で通知をリアルタイム受信できる
+- State オブジェクトの保存・復元で再起動後も再接続可能
+- 型定義が完備され、エディタ補完が効く

--- a/docs/specs/library-api/scope.md
+++ b/docs/specs/library-api/scope.md
@@ -1,0 +1,60 @@
+# Scope: Library API
+
+## In Scope
+
+- `NotificationClient` クラス (EventEmitter ベース)
+  - `notification` イベント: 復号済み TwitterNotification を配信
+  - `connected` イベント: 接続完了時に ClientState を返す
+  - `error` イベント: エラー通知
+  - `disconnected` イベント: 切断通知
+  - `start()`: 接続開始 (state なしなら鍵生成 + Twitter 登録を自動実行)
+  - `stop()`: 切断
+- `createClient(options)` ファクトリ関数
+- `ClientState` 型 (シリアライズ可能な状態オブジェクト)
+- バレルエクスポート (`src/index.ts`)
+  - 高レベル: `createClient`, `NotificationClient`
+  - 型: `TwitterNotification`, `ClientState`, `NotificationClientOptions`
+  - 低レベル: `Decryptor`, `AutopushClient` (パワーユーザー向け)
+- CLI コード (`init` / `start` サブコマンド) の除去
+- Bun 固有 API (`Bun.file`, `Bun.write`) の除去
+  - `config.ts` → 削除 (状態管理はユーザー側)
+  - `handlers.ts` → 削除 (ConsoleHandler / FileHandler は不要)
+- `package.json` 更新: `private` 削除, `exports`, `types`, `files` 追加
+- `tsconfig.json` 更新: `declaration: true`, `outDir: "dist"`
+- `twitter.ts` の `console.log` 除去 (ライブラリはログを吐かない)
+- README.md をライブラリ用途に書き換え
+
+## Out of Scope
+
+- npm publish の CI/CD パイプライン (→ `npm-publish` エピック)
+- 通知フィルタリング機能
+- Webhook アダプタ
+- 複数アカウント対応
+- Node.js / Deno 互換テスト
+- テストスイート
+
+## Success Criteria (KPI)
+
+### Expected to Improve
+
+- ライブラリとしての利用可能性: 0 → 1 (import して使える)
+- セットアップコード行数: 10 行以内で通知受信開始
+- 型カバレッジ: 全公開 API に型定義あり
+
+### At Risk (may decrease)
+
+- CLI としての直接利用 (削除されるため)
+
+## Acceptance Gates
+
+- [ ] `import { createClient } from "reverse-twitter-notifications"` が動作する
+- [ ] `client.on("notification", cb)` で通知を受信できる
+- [ ] `client.on("connected", cb)` で ClientState を取得できる
+- [ ] ClientState を保存→復元して再接続できる
+- [ ] `bun run build` で dist/ が生成される
+- [ ] `Bun.file` / `Bun.write` がライブラリコードに存在しない
+- [ ] `console.log` がライブラリコードに存在しない (error のみ許容しない)
+
+## Experiment Info (if applicable)
+
+N/A — 構造変更のため実験なし


### PR DESCRIPTION
## 概要

CLI ツールからライブラリへ転換し、EventEmitter ベースの `NotificationClient` を公開 API として提供する。

## 背景・目的

Bot/自動化開発者が Twitter 通知をプログラムから利用できるよう、ライブラリ化する。コアロジックは既にモジュール分割済みで、高レベル API を被せてエクスポートする。

## スペック

- `docs/specs/library-api/overview.md`
- `docs/specs/library-api/scope.md`

## レビュー観点

- [ ] 課題設定は妥当か
- [ ] スコープは適切か
- [ ] 完了条件は明確で検証可能か
- [ ] 見落としているリスクはないか