### PR TITLE
docs: add NotificationClient feature spec

### DIFF
--- a/docs/specs/library-api/client/design.md
+++ b/docs/specs/library-api/client/design.md
@@ -1,0 +1,117 @@
+# Design: NotificationClient
+
+## Current State
+
+CLI ツールとして動作。`src/index.ts` が `process.argv` でサブコマンドを分岐し、各モジュールを直接呼び出す。
+
+```
+src/
+├── index.ts      ← CLI エントリポイント (init/start サブコマンド)
+├── autopush.ts   ← Autopush WebSocket クライアント
+├── decrypt.ts    ← AESGCM 復号
+├── twitter.ts    ← Twitter push 登録
+├── handlers.ts   ← ConsoleHandler / FileHandler / CallbackHandler
+├── config.ts     ← config.json 読み書き (Bun.file 依存)
+├── types.ts      ← 型定義
+└── utils.ts      ← base64url / buffer ユーティリティ
+```
+
+I/O を持つモジュール: `config.ts` (Bun.file), `handlers.ts` (Bun.file, console.log)
+CLI 固有: `index.ts` (process.argv, prompt)
+
+## Proposed Changes
+
+### ファイル構成
+
+```
+src/
+├── index.ts      ← バレルエクスポート (公開 API)
+├── client.ts     ← NotificationClient (新規)
+├── autopush.ts   ← 変更なし (console.log 除去のみ)
+├── decrypt.ts    ← 変更なし
+├── twitter.ts    ← console.log 除去
+├── types.ts      ← ClientState, NotificationClientOptions 追加
+└── utils.ts      ← 変更なし
+```
+
+**削除するファイル:**
+- `config.ts` — 状態管理はユーザー側の責務
+- `handlers.ts` — ライブラリは handler パターンを使わない (EventEmitter で直接配信)
+
+### 公開 API
+
+```typescript
+// src/index.ts (バレルエクスポート)
+export { NotificationClient, createClient } from "./client";
+export { Decryptor } from "./decrypt";
+export { AutopushClient } from "./autopush";
+export type {
+  TwitterNotification,
+  ClientState,
+  NotificationClientOptions,
+  AutopushNotification,
+} from "./types";
+```
+
+### NotificationClient
+
+```typescript
+// src/client.ts
+interface NotificationClientEvents {
+  notification: (notification: TwitterNotification) => void;
+  connected: (state: ClientState) => void;
+  error: (error: Error) => void;
+  disconnected: () => void;
+  reconnecting: () => void;
+}
+
+class NotificationClient extends TypedEventEmitter<NotificationClientEvents> {
+  start(): Promise<void>;
+  stop(): void;
+}
+
+function createClient(options: NotificationClientOptions): NotificationClient;
+```
+
+### ClientState
+
+```typescript
+// Config から cookies を除外し、シリアライズ可能な形にしたもの
+interface ClientState {
+  uaid: string;
+  channelId: string;
+  endpoint: string;
+  remoteBroadcasts: Record<string, string>;
+  decryptor: {
+    jwk: JsonWebKey;
+    auth: string; // base64url
+  };
+}
+```
+
+### NotificationClientOptions
+
+```typescript
+interface NotificationClientOptions {
+  cookies: { auth_token: string; ct0: string };
+  state?: ClientState;
+}
+```
+
+### package.json 変更
+
+- `"private": true` → 削除
+- `"exports"` 追加: `{ ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } }`
+- `"files": ["dist"]`
+- `"scripts.build"` 追加
+- `"scripts.init"` / `"scripts.start"` 削除
+
+### tsconfig.json 変更
+
+- `"noEmit": true` → `"noEmit": false`
+- `"declaration": true`, `"declarationMap": true` 追加
+- `"outDir": "dist"` 追加
+
+## Tracking
+
+N/A — ライブラリのため計測イベントなし

--- a/docs/specs/library-api/client/requirements.md
+++ b/docs/specs/library-api/client/requirements.md
@@ -1,0 +1,54 @@
+# Requirements: NotificationClient
+
+## Functional Requirements
+
+### P1 (Must have)
+
+- `createClient(options)` でクライアントインスタンスを生成できる
+  - `options.cookies`: `{ auth_token: string, ct0: string }` — 必須
+  - `options.state`: `ClientState` — 省略可。省略時は鍵生成 + Twitter 登録を自動実行
+- `client.start()` で Autopush への接続を開始し、通知受信を開始する
+  - state が渡されていれば既存の鍵/接続情報で復元接続
+  - state がなければ ECDH 鍵生成 → Autopush 接続 → Twitter push 登録を一連で実行
+- `client.stop()` で接続を切断する
+- `client.on("notification", cb)` で復号済み `TwitterNotification` を受信できる
+- `client.on("connected", cb)` で接続完了時に `ClientState` を受け取れる
+  - `ClientState` はシリアライズ可能 (JSON.stringify/parse でラウンドトリップ可能)
+  - 含むフィールド: `uaid`, `channelId`, `endpoint`, `remoteBroadcasts`, `decryptor` (JWK + auth)
+  - cookies は含まない
+- `client.on("error", cb)` でエラーを受け取れる
+- `client.on("disconnected", cb)` で切断を検知できる
+- 切断時は指数バックオフ (1s → 60s max) で自動再接続する
+  - 再接続成功時にバックオフをリセット
+  - 再接続時に `connected` イベントを再発行
+
+### P2 (Should have)
+
+- バレルエクスポートから低レベル API (`Decryptor`, `AutopushClient`) も利用できる
+- `bun run build` で `dist/` に型定義付き JS を出力できる
+
+### P3 (Nice to have)
+
+- `client.on("reconnecting", cb)` で再接続試行を検知できる
+
+## Non-Functional Requirements
+
+- ライブラリコードに `console.log` / `console.error` を含まない
+- ライブラリコードに `Bun.file` / `Bun.write` を含まない (Web 標準 API のみ)
+- 全公開 API に TypeScript 型定義がある
+- EventEmitter は型安全 (イベント名とコールバック型が対応)
+
+## Edge Cases
+
+1. **start() を複数回呼ぶ**: 既に接続中なら何もしない (二重接続しない)
+2. **stop() 後に start()**: 再接続できる (使い捨てではない)
+3. **Twitter 登録失敗**: error イベントを発行し、接続自体は維持 (Autopush は使える)
+4. **復号失敗**: error イベントを発行し、接続は維持。次の通知は正常に処理される
+5. **不正な state**: start() で検証し、不正なら新規生成にフォールバック
+6. **cookies 未指定**: createClient() で即座にエラーをスローする
+
+## Constraints
+
+- ランタイム: 当面 Bun 対象 (Web 標準 API のみ使用するため将来的に Node/Deno 対応可能)
+- 外部依存: `twitter-openapi-typescript` (Twitter 登録のみ)
+- VAPID key はライブラリ内にハードコード (Twitter の公開鍵、変更頻度は極めて低い)


### PR DESCRIPTION
## Summary

NotificationClient (EventEmitter ベース) のフィーチャースペック。要件定義と設計を文書化。

## Specs

- `docs/specs/library-api/client/requirements.md`
- `docs/specs/library-api/client/design.md`

## Review checklist

- [ ] 要件は明確で検証可能か
- [ ] 設計は既存パターンと整合しているか
- [ ] エッジケースは網羅されているか