### PR TITLE
docs: add workspace-setup epic spec

### DIFF
--- a/docs/specs/workspace-setup/overview.md
+++ b/docs/specs/workspace-setup/overview.md
@@ -1,0 +1,26 @@
+# Workspace Setup
+
+## Summary
+
+bun workspace で monorepo 化し、ライブラリ本体を `packages/core/` に移動、`examples/cli/` に元の CLI 動作を再現するサンプルを配置する。
+
+## Background & Purpose
+
+ライブラリ化 (#2) で CLI を削除したが、元の CLI 動作 (init + start でコンソール出力 + JSON 保存) はライブラリの使い方のリファレンスとして価値がある。monorepo 構成にすることで、ライブラリ本体とサンプルを同一リポジトリで管理し、API 変更時にサンプルも同時に更新できる。
+
+## Why Now
+
+- ライブラリ化が完了した直後で、構造変更のコストが最小
+- npm publish 前にパッケージ配置を確定させる必要がある
+- examples がないと利用者が使い方を把握しにくい
+
+## Hypothesis
+
+- If we provide a working CLI example using the library API, then new users can understand the library's usage pattern within minutes
+- If we use monorepo structure, then examples always stay in sync with the library API
+
+## Expected Outcome
+
+- `packages/core/` にライブラリ本体、`examples/cli/` にサンプルが配置される
+- `bun install` で workspace 全体の依存が解決される
+- `bun run --cwd examples/cli start` で元の CLI と同等の動作が確認できる

--- a/docs/specs/workspace-setup/scope.md
+++ b/docs/specs/workspace-setup/scope.md
@@ -1,0 +1,42 @@
+# Scope: Workspace Setup
+
+## In Scope
+
+- ルート package.json を workspace root に変更 (`workspaces: ["packages/*", "examples/*"]`)
+- `src/`, `tsconfig.json` を `packages/core/` に移動
+- `packages/core/package.json` にライブラリ設定を移管
+- `examples/cli/` に CLI サンプルを作成
+  - 元の `init` / `start` サブコマンドの動作をライブラリ API で再現
+  - コンソール出力 + JSON ファイル保存 + config.json 永続化
+- `bun install` で workspace 依存解決が動作する
+- README.md に monorepo 構成の説明を追加
+
+## Out of Scope
+
+- npm publish パイプライン
+- 追加のサンプル (basic, file-logger 等)
+- CI/CD 設定
+- テストスイート
+
+## Success Criteria (KPI)
+
+### Expected to Improve
+
+- 開発体験: ライブラリとサンプルを同一リポジトリで管理
+- ドキュメント性: examples/cli が実動するリファレンス実装として機能
+
+### At Risk (may decrease)
+
+- リポジトリの初期理解コスト (ディレクトリ構造が深くなる)
+
+## Acceptance Gates
+
+- [ ] `bun install` が workspace 全体で成功する
+- [ ] `bun run --cwd packages/core build` でライブラリがビルドできる
+- [ ] `examples/cli` から `reverse-twitter-notifications` を import できる
+- [ ] `bun run --cwd examples/cli start` で通知受信が動作する (元 CLI と同等)
+- [ ] ルートの `src/` が存在しない (packages/core/ に移動済み)
+
+## Experiment Info (if applicable)
+
+N/A


### PR DESCRIPTION
## Summary

bun workspace で monorepo 化し、ライブラリを `packages/core/` に移動、`examples/cli/` に元 CLI 動作のサンプルを配置する。

## Background

ライブラリ化 (#2) で CLI を削除したが、元の動作はリファレンス実装として価値がある。npm publish 前にパッケージ配置を確定させる。

## Specs

- `docs/specs/workspace-setup/overview.md`
- `docs/specs/workspace-setup/scope.md`

## Review checklist

- [ ] 課題設定は妥当か
- [ ] スコープは適切か
- [ ] 完了条件は明確で検証可能か
- [ ] 見落としているリスクはないか