### PR TITLE
docs: npm-publish pipeline spec

### DIFF
--- a/docs/specs/npm-publish/pipeline/design.md
+++ b/docs/specs/npm-publish/pipeline/design.md
@@ -1,0 +1,79 @@
+# Design: npm publish pipeline
+
+## Current State
+
+- パッケージ名: `reverse-twitter-notifications`（長い）
+- バージョン: 0.1.0（npm 未公開）
+- CI/CD: なし（`.github/workflows/` が存在しない）
+- Linter/Formatter: なし
+- changesets: 未導入
+
+## Proposed Changes
+
+### 1. パッケージ名変更
+
+`reverse-twitter-notifications` → `xnotif`
+
+変更箇所:
+- `packages/core/package.json` の `name`
+- `examples/cli/package.json` の `dependencies`
+- `README.md` のインストールコマンド・パッケージ参照
+- `examples/cli/index.ts` の import 文
+
+### 2. npm メタデータ追加
+
+`packages/core/package.json` に以下を追加:
+
+| Field | Value |
+|-------|-------|
+| description | "Receive Twitter/X push notifications programmatically via Mozilla Autopush" |
+| keywords | twitter, x, push, notifications, autopush, webpush |
+| repository | `{ "type": "git", "url": "https://github.com/yutakobayashidev/reverse-twitter-notifications" }` |
+| homepage | GitHub repo URL |
+| bugs | GitHub issues URL |
+| author | yutakobayashidev |
+| license | MIT |
+
+### 3. changesets 導入
+
+- `@changesets/cli` をルート devDependency に追加
+- `.changeset/config.json` を作成（access: public, baseBranch: main）
+- pre-release mode を `beta` タグで開始
+
+### 4. oxlint + oxfmt 導入
+
+- `oxlint` と `oxfmt` をルート devDependency に追加
+- ルートに設定ファイルを配置（必要に応じて）
+- `package.json` scripts に `lint` と `format:check` を追加
+
+### 5. GitHub Actions ワークフロー
+
+#### CI ワークフロー (`.github/workflows/ci.yml`)
+
+トリガー: push to main, pull_request
+
+| Step | Command |
+|------|---------|
+| Install | `bun install --frozen-lockfile` |
+| Build | `bun run build` |
+| Type-check | `bun run --cwd packages/core tsc --noEmit` |
+| Lint | `oxlint` |
+| Format check | `oxfmt --check` |
+
+#### Release ワークフロー (`.github/workflows/release.yml`)
+
+トリガー: push to main
+
+changesets/action を使用:
+- changeset がある場合 → Version PR を作成/更新
+- Version PR がマージされた場合 → npm publish (`--tag beta`)
+
+NPM_TOKEN を GitHub Secrets に設定する必要がある。
+
+## Tracking
+
+| Event Name | Properties | Trigger Condition |
+|------------|------------|-------------------|
+| npm publish | version, tag | Version PR merge |
+| CI pass | workflow, duration | PR / push to main |
+| CI fail | workflow, step, error | Any step failure |

--- a/docs/specs/npm-publish/pipeline/requirements.md
+++ b/docs/specs/npm-publish/pipeline/requirements.md
@@ -1,0 +1,48 @@
+# Requirements: npm publish pipeline
+
+## Functional Requirements
+
+### P1 (Must have)
+
+- パッケージ名を `xnotif` に変更し、npm レジストリから `bun add xnotif@beta` でインストールできる
+- changesets で PR 単位のバージョン変更を管理できる
+  - pre-release mode で `0.1.0-beta.x` としてバージョニングする
+  - main マージ時に Version PR が自動作成される
+  - Version PR マージ時に npm publish が `beta` dist-tag で実行される
+- GitHub Actions CI が PR で自動実行される
+  - build (`bun run build`)
+  - type-check (`tsc --noEmit`)
+  - lint (`oxlint`)
+- `packages/core/package.json` に npm メタデータが英語で設定されている
+  - description, keywords, repository, homepage, bugs, author, license
+
+### P2 (Should have)
+
+- oxfmt による format check が CI に含まれる
+- changeset bot が PR にバージョン変更の有無をコメントする
+- CHANGELOG.md が changesets release 時に自動生成される
+
+### P3 (Nice to have)
+
+- `oxfmt --migrate prettier` 相当の設定（将来の Prettier 移行パスが不要になる）
+
+## Non-Functional Requirements
+
+- CI は 1 分以内に完了する（oxlint + oxfmt は Rust 製で高速）
+- NPM_TOKEN は GitHub Secrets で管理し、ワークフロー外に露出しない
+- monorepo 構成で `packages/core` のみ publish 対象（root と examples は private）
+
+## Edge Cases
+
+1. changeset なしの PR（docs のみ等）→ changeset bot が警告するが CI は通る
+2. pre-release mode 中に breaking change → minor bump（0.x なので patch でも可）
+3. npm publish 失敗（token 期限切れ等）→ ワークフローが失敗し、再実行で復旧可能
+4. パッケージ名変更時、workspace:* 参照の examples/cli が壊れないこと
+
+## Constraints
+
+- ランタイム: Bun (CI でも bun を使用)
+- Linter: oxlint（Biome ではなく OXC ツールチェイン）
+- Formatter: oxfmt beta
+- バージョン管理: changesets pre-release mode
+- 初回バージョン: 0.1.0-beta.0


### PR DESCRIPTION
## 概要

changesets + oxlint/oxfmt + GitHub Actions CI/CD で npm レジストリに `xnotif` として公開するための feature spec。

## スペック

- `docs/specs/npm-publish/pipeline/requirements.md`
- `docs/specs/npm-publish/pipeline/design.md`

## レビュー観点

- [ ] 要件は明確で検証可能か
- [ ] 設計は既存パターンと整合しているか
- [ ] エッジケースは網羅されているか