### PR TITLE
refactor: remove twitter-openapi-typescript dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,10 +34,7 @@
     "build": "tsdown src/index.ts --format esm",
     "test": "vitest run --coverage"
   },
-  "dependencies": {
-    "twitter-openapi-typescript": "^0.0.55",
-    "twitter-openapi-typescript-generated": "^0.0.38"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.0.18",

--- a/packages/core/src/integration.test.ts
+++ b/packages/core/src/integration.test.ts
@@ -3,41 +3,43 @@ import type { ClientState, TwitterNotification } from "./types";
 import { bufferToBase64url } from "./utils";
 import { webPushEncrypt } from "./test-encrypt";
 
-let capturedSubscription: { p256dh: string; auth: string } | null = null;
+const HEADER_URL =
+  "https://raw.githubusercontent.com/fa0311/latest-user-agent/refs/heads/main/header.json";
+const PAIR_URL =
+  "https://raw.githubusercontent.com/fa0311/x-client-transaction-pair-dict/refs/heads/main/pair.json";
 
-vi.mock("twitter-openapi-typescript-generated", async () => {
-  const actual = await vi.importActual("twitter-openapi-typescript-generated");
-  return {
-    ...actual,
-    BaseAPI: class MockBaseAPI {
-      configuration: any;
-      constructor(config: any) {
-        this.configuration = config;
-      }
-      async request(context: any): Promise<Response> {
-        if (context.body?.push_device_info) {
+const fakeHeaders = {
+  "chrome-fetch": {
+    accept: "*/*",
+    "user-agent": "MockChrome/1.0",
+  },
+};
+const fakePairs = [{ verification: "dGVzdA", animationKey: "abc123" }];
+
+let capturedSubscription: { p256dh: string; auth: string } | null = null;
+const originalFetch = globalThis.fetch;
+
+function stubFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url === HEADER_URL) return new Response(JSON.stringify(fakeHeaders));
+      if (url === PAIR_URL) return new Response(JSON.stringify(fakePairs));
+      // registerPush call — capture subscription info
+      if (init?.body) {
+        const body = JSON.parse(init.body as string);
+        if (body.push_device_info) {
           capturedSubscription = {
-            p256dh: context.body.push_device_info.encryption_key1,
-            auth: context.body.push_device_info.encryption_key2,
+            p256dh: body.push_device_info.encryption_key1,
+            auth: body.push_device_info.encryption_key2,
           };
         }
-        return new Response("ok", { status: 200 });
       }
-    },
-  };
-});
-
-vi.mock("twitter-openapi-typescript", () => ({
-  TwitterOpenApi: class {
-    getClientFromCookies = vi.fn().mockResolvedValue({
-      config: {
-        apiKey: vi.fn().mockResolvedValue("mock-value"),
-        accessToken: vi.fn().mockResolvedValue("mock-token"),
-      },
-      initOverrides: vi.fn().mockReturnValue(vi.fn()),
-    });
-  },
-}));
+      return new Response("ok", { status: 200 });
+    }),
+  );
+}
 
 class AutoRespondWebSocket {
   static CONNECTING = 0 as const;
@@ -99,10 +101,12 @@ describe("integration", () => {
   beforeEach(() => {
     AutoRespondWebSocket.reset();
     capturedSubscription = null;
+    stubFetch();
     vi.stubGlobal("WebSocket", AutoRespondWebSocket);
   });
 
   afterEach(() => {
+    vi.stubGlobal("fetch", originalFetch);
     vi.restoreAllMocks();
   });
 

--- a/packages/core/src/twitter.test.ts
+++ b/packages/core/src/twitter.test.ts
@@ -1,44 +1,44 @@
-import { beforeEach, describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi, afterEach } from "vitest";
+import { createClient, registerPush, type PushSubscription, type TwitterClient } from "./twitter";
 
-let lastRequestContext: any = null;
-let mockResponse: Response = new Response("ok", { status: 200 });
+const HEADER_URL =
+  "https://raw.githubusercontent.com/fa0311/latest-user-agent/refs/heads/main/header.json";
+const PAIR_URL =
+  "https://raw.githubusercontent.com/fa0311/x-client-transaction-pair-dict/refs/heads/main/pair.json";
 
-vi.mock("twitter-openapi-typescript-generated", async () => {
-  const actual = await vi.importActual("twitter-openapi-typescript-generated");
-  return {
-    ...actual,
-    BaseAPI: class MockBaseAPI {
-      configuration: any;
-      constructor(config: any) {
-        this.configuration = config;
-      }
-      async request(context: any, _initOverride?: any): Promise<Response> {
-        lastRequestContext = context;
-        return mockResponse;
-      }
-    },
-  };
-});
-
-const mockGetClientFromCookies = vi.fn();
-
-vi.mock("twitter-openapi-typescript", () => ({
-  TwitterOpenApi: class {
-    getClientFromCookies = mockGetClientFromCookies;
+const fakeHeaders = {
+  "chrome-fetch": {
+    accept: "*/*",
+    "user-agent": "MockChrome/1.0",
+    "sec-fetch-dest": "empty",
+    "sec-fetch-mode": "cors",
+    "sec-fetch-site": "same-origin",
   },
-}));
+};
 
-import { createClient, registerPush, type PushSubscription } from "./twitter";
-import type { TwitterOpenApiClient } from "twitter-openapi-typescript";
+const fakePairs = [{ verification: "dGVzdA", animationKey: "abc123" }];
 
-function makeMockClient(): TwitterOpenApiClient {
-  return {
-    config: {
-      apiKey: vi.fn().mockResolvedValue("mock-header-value"),
-      accessToken: vi.fn().mockResolvedValue("mock-access-token"),
-    },
-    initOverrides: vi.fn().mockReturnValue(vi.fn()),
-  } as unknown as TwitterOpenApiClient;
+let lastFetchUrl: string | undefined;
+let lastFetchInit: RequestInit | undefined;
+let mockRegisterResponse: Response;
+
+const originalFetch = globalThis.fetch;
+
+function stubFetch() {
+  mockRegisterResponse = new Response("ok", { status: 200 });
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url === HEADER_URL) return new Response(JSON.stringify(fakeHeaders));
+      if (url === PAIR_URL) return new Response(JSON.stringify(fakePairs));
+      // API call
+      lastFetchUrl = url;
+      lastFetchInit = init;
+      return mockRegisterResponse;
+    }),
+  );
 }
 
 const testSubscription: PushSubscription = {
@@ -48,37 +48,77 @@ const testSubscription: PushSubscription = {
 };
 
 describe("twitter", () => {
-  describe("createClient", () => {
-    it("calls getClientFromCookies with the provided cookies", async () => {
-      const cookies = { ct0: "csrf-token", auth_token: "auth123" };
-      const fakeClient = makeMockClient();
-      mockGetClientFromCookies.mockResolvedValue(fakeClient);
+  beforeEach(() => {
+    lastFetchUrl = undefined;
+    lastFetchInit = undefined;
+    stubFetch();
+  });
 
-      const result = await createClient(cookies);
-      expect(mockGetClientFromCookies).toHaveBeenCalledWith(cookies);
-      expect(result).toBe(fakeClient);
+  afterEach(() => {
+    vi.stubGlobal("fetch", originalFetch);
+  });
+
+  describe("createClient", () => {
+    it("fetches headers and pairs, maps cookies to auth headers", async () => {
+      const client = await createClient({ ct0: "csrf-token", auth_token: "auth123" });
+
+      expect(client.headers["x-csrf-token"]).toBe("csrf-token");
+      expect(client.headers["x-twitter-auth-type"]).toBe("OAuth2Session");
+      expect(client.headers["authorization"]).toMatch(/^Bearer /);
+      expect(client.headers["user-agent"]).toBe("MockChrome/1.0");
+      expect(client.pairs).toEqual(fakePairs);
+    });
+
+    it("sets x-guest-token when gt cookie is present", async () => {
+      const client = await createClient({ gt: "guest-123" });
+      expect(client.headers["x-guest-token"]).toBe("guest-123");
+    });
+
+    it("excludes host and connection from fetched headers", async () => {
+      const headersWithHostConn = {
+        "chrome-fetch": {
+          host: "x.com",
+          connection: "keep-alive",
+          accept: "*/*",
+        },
+      };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | URL | Request) => {
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+          if (url === HEADER_URL) return new Response(JSON.stringify(headersWithHostConn));
+          if (url === PAIR_URL) return new Response(JSON.stringify(fakePairs));
+          return new Response("ok");
+        }),
+      );
+
+      const client = await createClient({ ct0: "t" });
+      expect(client.headers["host"]).toBeUndefined();
+      expect(client.headers["connection"]).toBeUndefined();
+      expect(client.headers["accept"]).toBe("*/*");
     });
   });
 
   describe("registerPush", () => {
-    beforeEach(() => {
-      lastRequestContext = null;
-      mockResponse = new Response("ok", { status: 200 });
+    let client: TwitterClient;
+
+    beforeEach(async () => {
+      client = await createClient({ ct0: "csrf", auth_token: "tok" });
     });
 
     it("sends POST to /1.1/notifications/settings/login.json", async () => {
-      const client = makeMockClient();
       await registerPush(client, testSubscription);
 
-      expect(lastRequestContext.path).toBe("/1.1/notifications/settings/login.json");
-      expect(lastRequestContext.method).toBe("POST");
+      expect(lastFetchUrl).toBe("https://x.com/i/api/1.1/notifications/settings/login.json");
+      expect(lastFetchInit?.method).toBe("POST");
     });
 
     it("sends correct push_device_info body", async () => {
-      const client = makeMockClient();
       await registerPush(client, testSubscription);
 
-      expect(lastRequestContext.body).toEqual({
+      const body = JSON.parse(lastFetchInit!.body as string);
+      expect(body).toEqual({
         push_device_info: {
           os_version: "Web/Chrome",
           udid: "Web/Chrome",
@@ -92,49 +132,30 @@ describe("twitter", () => {
       });
     });
 
-    it("sets Content-Type header", async () => {
-      const client = makeMockClient();
+    it("includes required headers", async () => {
       await registerPush(client, testSubscription);
 
-      expect(lastRequestContext.headers["Content-Type"]).toBe("application/json");
-    });
-
-    it("populates API headers from config.apiKey", async () => {
-      const client = makeMockClient();
-      await registerPush(client, testSubscription);
-
-      const apiKey = client.config.apiKey as ReturnType<typeof vi.fn>;
-      expect(apiKey).toHaveBeenCalled();
-      const calledNames = apiKey.mock.calls.map((c: any[]) => c[0]);
-      expect(calledNames).toContain("x-csrf-token");
-      expect(calledNames).toContain("user-agent");
-    });
-
-    it("sets Authorization header from accessToken", async () => {
-      const client = makeMockClient();
-      await registerPush(client, testSubscription);
-
-      expect(lastRequestContext.headers["Authorization"]).toBe("Bearer mock-access-token");
+      const headers = lastFetchInit!.headers as Record<string, string>;
+      expect(headers["content-type"]).toBe("application/json");
+      expect(headers["x-csrf-token"]).toBe("csrf");
+      expect(headers["authorization"]).toMatch(/^Bearer /);
+      expect(headers["cookie"]).toContain("ct0=csrf");
+      expect(headers["x-client-transaction-id"]).toBeDefined();
     });
 
     it("does not throw on 200 response", async () => {
-      const client = makeMockClient();
       await expect(registerPush(client, testSubscription)).resolves.toBeUndefined();
     });
 
     it("throws on non-ok response (status 403)", async () => {
-      const client = makeMockClient();
-      mockResponse = new Response("Forbidden", { status: 403 });
-
+      mockRegisterResponse = new Response("Forbidden", { status: 403 });
       await expect(registerPush(client, testSubscription)).rejects.toThrow(
         "login.json failed (403): Forbidden",
       );
     });
 
     it("throws on non-ok response (status 500)", async () => {
-      const client = makeMockClient();
-      mockResponse = new Response("Internal Server Error", { status: 500 });
-
+      mockRegisterResponse = new Response("Internal Server Error", { status: 500 });
       await expect(registerPush(client, testSubscription)).rejects.toThrow(
         "login.json failed (500): Internal Server Error",
       );

--- a/packages/core/src/twitter.ts
+++ b/packages/core/src/twitter.ts
@@ -1,11 +1,9 @@
-import { TwitterOpenApi, type TwitterOpenApiClient } from "twitter-openapi-typescript";
-import {
-  BaseAPI,
-  type Configuration,
-  type HTTPHeaders,
-  type HTTPBody,
-  type InitOverrideFunction,
-} from "twitter-openapi-typescript-generated";
+const BEARER_TOKEN =
+  "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA";
+const HEADER_URL =
+  "https://raw.githubusercontent.com/fa0311/latest-user-agent/refs/heads/main/header.json";
+const PAIR_URL =
+  "https://raw.githubusercontent.com/fa0311/x-client-transaction-pair-dict/refs/heads/main/pair.json";
 
 export interface PushSubscription {
   endpoint: string;
@@ -13,80 +11,105 @@ export interface PushSubscription {
   auth: string; // base64url
 }
 
-// Header names populated by generated API classes via config.apiKey()
-const API_HEADER_NAMES = [
-  "Accept",
-  "x-twitter-client-language",
-  "Priority",
-  "Referer",
-  "Sec-Fetch-Dest",
-  "Sec-Ch-Ua-Platform",
-  "Sec-Fetch-Mode",
-  "x-csrf-token",
-  "x-client-uuid",
-  "x-guest-token",
-  "Sec-Ch-Ua",
-  "x-twitter-active-user",
-  "user-agent",
-  "Accept-Language",
-  "Sec-Fetch-Site",
-  "x-twitter-auth-type",
-  "Sec-Ch-Ua-Mobile",
-  "Accept-Encoding",
-];
-
-// Subclass BaseAPI to expose the protected request() method
-class NotificationApi extends BaseAPI {
-  constructor(config: Configuration) {
-    super(config);
-  }
-
-  async post(path: string, body: unknown, initOverride?: InitOverrideFunction): Promise<Response> {
-    const headers: HTTPHeaders = {};
-
-    // Populate headers from apiKey (same pattern as generated V11PostApi)
-    const apiKey = this.configuration.apiKey;
-    if (apiKey) {
-      for (const name of API_HEADER_NAMES) {
-        const value = await apiKey(name);
-        if (value) headers[name] = value;
-      }
-    }
-
-    // Authorization via accessToken
-    const accessToken = this.configuration.accessToken;
-    if (accessToken) {
-      headers["Authorization"] = `Bearer ${await accessToken()}`;
-    }
-
-    headers["Content-Type"] = "application/json";
-
-    return this.request({ path, method: "POST", headers, body: body as HTTPBody }, initOverride);
-  }
+export interface TwitterClient {
+  headers: Record<string, string>;
+  cookies: Record<string, string>;
+  pairs: Array<{ verification: string; animationKey: string }>;
 }
 
-export async function createClient(cookies: Record<string, string>): Promise<TwitterOpenApiClient> {
-  const api = new TwitterOpenApi();
-  return api.getClientFromCookies(cookies);
+// Vendored from x-client-transaction-id-generater/src/encode.js
+async function generateTransactionId(
+  method: string,
+  path: string,
+  key: string,
+  animationKey: string,
+): Promise<string> {
+  const DEFAULT_KEYWORD = "obfiowerehiring";
+  const ADDITIONAL_RANDOM_NUMBER = 3;
+  const timeNow = Math.floor((Date.now() - 1682924400 * 1000) / 1000);
+  const timeNowBytes = [
+    timeNow & 0xff,
+    (timeNow >> 8) & 0xff,
+    (timeNow >> 16) & 0xff,
+    (timeNow >> 24) & 0xff,
+  ];
+
+  const data = `${method}!${path}!${timeNow}${DEFAULT_KEYWORD}${animationKey}`;
+  const hashBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(data));
+  const hashBytes = Array.from(new Uint8Array(hashBuffer));
+  const keyBytes = Array.from(Buffer.from(key, "base64"));
+
+  const randomNum = Math.floor(Math.random() * 256);
+  const bytesArr = [
+    ...keyBytes,
+    ...timeNowBytes,
+    ...hashBytes.slice(0, 16),
+    ADDITIONAL_RANDOM_NUMBER,
+  ];
+  const out = new Uint8Array([randomNum, ...bytesArr.map((b) => b ^ randomNum)]);
+
+  return Buffer.from(out).toString("base64").replace(/=/g, "");
 }
 
-function makeInitOverride(client: TwitterOpenApiClient, path: string): InitOverrideFunction {
-  return client.initOverrides({
-    "@method": "POST",
-    "@path": path,
-  });
+function encodeCookies(cookies: Record<string, string>): string {
+  return Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("; ");
+}
+
+export async function createClient(cookies: Record<string, string>): Promise<TwitterClient> {
+  const [headerJson, pairs] = await Promise.all([
+    fetch(HEADER_URL).then((r) => r.json()),
+    fetch(PAIR_URL).then((r) => r.json()),
+  ]);
+
+  const ignore = new Set(["host", "connection"]);
+  const chromeFetch: Record<string, string> = Object.fromEntries(
+    Object.entries(headerJson["chrome-fetch"] as Record<string, string>).filter(
+      ([k]) => !ignore.has(k),
+    ),
+  );
+
+  const headers: Record<string, string> = {
+    ...chromeFetch,
+    "accept-encoding": "identity",
+    pragma: "no-cache",
+    referer: "https://x.com",
+    priority: "u=1, i",
+    "x-twitter-client-language": "en",
+    "x-twitter-active-user": "yes",
+    authorization: `Bearer ${BEARER_TOKEN}`,
+  };
+
+  if (cookies["ct0"]) {
+    headers["x-twitter-auth-type"] = "OAuth2Session";
+    headers["x-csrf-token"] = cookies["ct0"];
+  }
+  if (cookies["gt"]) {
+    headers["x-guest-token"] = cookies["gt"];
+  }
+
+  return { headers, cookies, pairs };
 }
 
 export async function registerPush(
-  client: TwitterOpenApiClient,
+  client: TwitterClient,
   subscription: PushSubscription,
 ): Promise<void> {
-  const api = new NotificationApi(client.config);
   const path = "/1.1/notifications/settings/login.json";
 
-  const res = await api.post(
-    path,
-    {
+  const pair = client.pairs[Math.floor(Math.random() * client.pairs.length)];
+  const tid = await generateTransactionId("POST", path, pair.verification, pair.animationKey);
+
+  const res = await fetch(`https://x.com/i/api${path}`, {
+    method: "POST",
+    headers: {
+      ...client.headers,
+      cookie: encodeCookies(client.cookies),
+      "content-type": "application/json",
+      "x-client-transaction-id": tid,
+    },
+    body: JSON.stringify({
       push_device_info: {
         os_version: "Web/Chrome",
         udid: "Web/Chrome",
@@ -97,9 +120,8 @@ export async function registerPush(
         encryption_key1: subscription.p256dh,
         encryption_key2: subscription.auth,
       },
-    },
-    makeInitOverride(client, path),
-  );
+    }),
+  });
 
   if (!res.ok) {
     const text = await res.text();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,13 +35,6 @@ importers:
         version: 4.21.0
 
   packages/core:
-    dependencies:
-      twitter-openapi-typescript:
-        specifier: ^0.0.55
-        version: 0.0.55
-      twitter-openapi-typescript-generated:
-        specifier: ^0.0.38
-        version: 0.0.38
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1024,9 +1017,6 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
-  boolbase@1.0.0:
-    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -1050,13 +1040,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-select@5.2.2:
-    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
-
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
-    engines: {node: '>= 6'}
-
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
@@ -1067,19 +1050,6 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
-
-  dom-serializer@2.0.0:
-    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
-
-  domelementtype@2.3.0:
-    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-
-  domhandler@5.0.3:
-    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
-    engines: {node: '>= 4'}
-
-  domutils@3.2.2:
-    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dts-resolver@2.1.3:
     resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
@@ -1097,10 +1067,6 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
-
-  entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -1179,10 +1145,6 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
 
   hookable@6.0.1:
     resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
@@ -1347,12 +1309,6 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  node-html-parser@7.0.2:
-    resolution: {integrity: sha512-DxodLVh7a6JMkYzWyc8nBX9MaF4M0lLFYkJHlWOiu7+9/I6mwNK9u5TbAMC7qfqDJEPX9OIoWA2A9t4C2l1mUQ==}
-
-  nth-check@2.1.1:
-    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1621,12 +1577,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  twitter-openapi-typescript-generated@0.0.38:
-    resolution: {integrity: sha512-7BvPYNeq7W1eAk6H1ZcQLZ8oyA9ma2OGT279+8BbeuNqFpITMK/odqhJbBsQ7dG/dgCcCTkRv49gShtUHCSxng==}
-
-  twitter-openapi-typescript@0.0.55:
-    resolution: {integrity: sha512-VuvrUMHtMOWumTRxRxtr+MmTHExvtycKoR3cL9sY8L0ZQ5LhqlZVWnUyHW3hCwaSlfeiqQJPA8rWnW3GDUZHgg==}
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1735,9 +1685,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  x-client-transaction-id-generater@0.0.7:
-    resolution: {integrity: sha512-lLIozd8PLITaCwVGvlaOcCczkI/Q/C2zeu69DrBUpIj9rI/Gb0nsxk+f9jS0sexo3frsouxc0JeEw9Bv3C9lxw==}
 
 snapshots:
 
@@ -2486,8 +2433,6 @@ snapshots:
 
   birpc@4.0.0: {}
 
-  boolbase@1.0.0: {}
-
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -2506,16 +2451,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-select@5.2.2:
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.2.2
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      nth-check: 2.1.1
-
-  css-what@6.2.2: {}
-
   defu@6.1.4: {}
 
   detect-indent@6.1.0: {}
@@ -2523,24 +2458,6 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  dom-serializer@2.0.0:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      entities: 4.5.0
-
-  domelementtype@2.3.0: {}
-
-  domhandler@5.0.3:
-    dependencies:
-      domelementtype: 2.3.0
-
-  domutils@3.2.2:
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
 
   dts-resolver@2.1.3: {}
 
@@ -2550,8 +2467,6 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
-
-  entities@4.5.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -2654,8 +2569,6 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
-
-  he@1.2.0: {}
 
   hookable@6.0.1: {}
 
@@ -2790,15 +2703,6 @@ snapshots:
   mri@1.2.0: {}
 
   nanoid@3.3.11: {}
-
-  node-html-parser@7.0.2:
-    dependencies:
-      css-select: 5.2.2
-      he: 1.2.0
-
-  nth-check@2.1.1:
-    dependencies:
-      boolbase: 1.0.0
 
   obug@2.1.1: {}
 
@@ -3110,13 +3014,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  twitter-openapi-typescript-generated@0.0.38: {}
-
-  twitter-openapi-typescript@0.0.55:
-    dependencies:
-      twitter-openapi-typescript-generated: 0.0.38
-      x-client-transaction-id-generater: 0.0.7
-
   typescript@5.9.3: {}
 
   unconfig-core@7.5.0:
@@ -3190,7 +3087,3 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  x-client-transaction-id-generater@0.0.7:
-    dependencies:
-      node-html-parser: 7.0.2


### PR DESCRIPTION
## Summary

- `twitter-openapi-typescript` (660KB) + `twitter-openapi-typescript-generated` (6.2MB) + 推移的依存 (~800KB) を削除し、~100行の自前実装に置換
- `generateTransactionId` を `x-client-transaction-id-generater/encode.js` から vendor（SHA-256 + base64 のみ）
- cookie → 認証ヘッダーのマッピングと `pair.json`/`header.json` の fetch を直接実装し、素の `fetch` で Twitter API を呼び出す
- runtime の外部依存がゼロに

## Test plan

- [x] 全60テスト通過（`twitter.ts` カバレッジ 100%）
- [x] ビルド成功
- [x] lint / format パス
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)